### PR TITLE
Fix crash in production

### DIFF
--- a/Classes/BFPaperTableViewCell.m
+++ b/Classes/BFPaperTableViewCell.m
@@ -371,22 +371,23 @@ static CGFloat const bfPaperCell_fadeConstant                    = 0.15f;
 {
     //NSLog(@"Fading away");
     
-    CALayer *tempAnimationLayer = [self.rippleAnimationQueue firstObject];
     if (self.rippleAnimationQueue.count > 0) {
+        CALayer *tempAnimationLayer = [self.rippleAnimationQueue firstObject];
         [self.rippleAnimationQueue removeObjectAtIndex:0];
+        
+        [self.deathRowForCircleLayers addObject:tempAnimationLayer];
+        
+        CABasicAnimation *fadeOut = [CABasicAnimation animationWithKeyPath:@"opacity"];
+        [fadeOut setValue:@"fadeCircleOut" forKey:@"id"];
+        fadeOut.delegate = self;
+        fadeOut.fromValue = [NSNumber numberWithFloat:tempAnimationLayer.opacity];
+        fadeOut.toValue = [NSNumber numberWithFloat:0.f];
+        fadeOut.duration = bfPaperCell_tapCircleGrowthDurationConstant;
+        fadeOut.fillMode = kCAFillModeForwards;
+        fadeOut.removedOnCompletion = NO;
+        
+        [tempAnimationLayer addAnimation:fadeOut forKey:@"opacityAnimation"];
     }
-    [self.deathRowForCircleLayers addObject:tempAnimationLayer];
-    
-    CABasicAnimation *fadeOut = [CABasicAnimation animationWithKeyPath:@"opacity"];
-    [fadeOut setValue:@"fadeCircleOut" forKey:@"id"];
-    fadeOut.delegate = self;
-    fadeOut.fromValue = [NSNumber numberWithFloat:tempAnimationLayer.opacity];
-    fadeOut.toValue = [NSNumber numberWithFloat:0.f];
-    fadeOut.duration = bfPaperCell_tapCircleGrowthDurationConstant;
-    fadeOut.fillMode = kCAFillModeForwards;
-    fadeOut.removedOnCompletion = NO;
-    
-    [tempAnimationLayer addAnimation:fadeOut forKey:@"opacityAnimation"];
 }
 #pragma mark -
 


### PR DESCRIPTION
**\* -[__NSArrayM insertObject:atIndex:]: object cannot be nil
(null)
(
    0   CoreFoundation                      0x2f855feb  + 154
    1   libobjc.A.dylib                     0x3a33accf
objc_exception_throw + 38
    2   CoreFoundation                      0x2f78ff5d
CFStringConvertNSStringEncodingToEncoding + 0
    3   zsh                                 0x268973
-[BFPaperTableViewCell fadeTapCircleOut] + 366
    4   zsh                                 0x265679
-[BFPaperTableViewCell touchesEnded:withEvent:] + 300
    5   UIKit                               0x321f8795  + 232
    6   UIKit                               0x321f8795  + 232
    7   UIKit                               0x320a6721  + 528
    8   UIKit                               0x320a16eb  + 758
    9   UIKit                               0x320768ed  + 196
    10  UIKit                               0x32074f97  + 7102
    11  CoreFoundation                      0x2f82125b  + 14
    12  CoreFoundation                      0x2f82072b  + 206
    13  CoreFoundation                      0x2f81ef1f  + 622
    14  CoreFoundation                      0x2f789f0f
CFRunLoopRunSpecific + 522
    15  CoreFoundation                      0x2f789cf3 CFRunLoopRunInMode
- 106
  16  GraphicsServices                    0x34683663 GSEventRunModal +
  138
  17  UIKit                               0x320d516d UIApplicationMain +
  1136
  18  zsh                                 0xe8df7 main + 166
  19  libdyld.dylib                       0x3a847ab7  + 2
  )
