### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ After that, you can use it just like any other `UITableViewCell`.
 
 If you use storyboards with prototype cells, be sure to change the prototype cell's class to _BFPaperTableViewCell_!
 
-###Example
+### Example
 ```objective-c
 // Register BFPaperTableViewCell for our tableView in viewDidLoad:
 - (void)viewDidLoad


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
